### PR TITLE
fix(talos): tune nami ethernet to prevent packet drops

### DIFF
--- a/talos/patches/intel-nuc-e1000e/ethernet-tuning.yaml
+++ b/talos/patches/intel-nuc-e1000e/ethernet-tuning.yaml
@@ -1,0 +1,29 @@
+---
+# Comprehensive e1000e driver tuning for Intel I219-V on nami (192.168.1.50)
+#
+# Problem: Intel I219-V network adapter experiencing packet drops under high Ceph
+# storage traffic load, triggering CephNodeNetworkPacketDrops alert.
+#
+# Root Causes:
+# 1. Default ring buffers (256) too small for high-throughput storage workloads
+# 2. Known e1000e driver bugs with TSO/GSO/GRO hardware offload features
+#
+# Solution: Increase ring buffers and disable problematic offload features
+#
+# References:
+# - https://forum.proxmox.com/threads/e1000e-reset-adapter-unexpectedly.87769/
+# - https://bugzilla.kernel.org/show_bug.cgi?id=213377
+# - https://www.talos.dev/v1.11/talos-guides/network/ethernet-config/
+# - onedr0p homelab community recommendation
+# - buroa k8s-gitops implementation pattern
+apiVersion: v1alpha1
+kind: EthernetConfig
+name: eno1
+rings:
+  rx: 4096  # Increase from default 256 to maximum 4096 (16x larger)
+  tx: 4096  # Prevents buffer exhaustion during Ceph traffic bursts
+features:
+  tx-tcp-segmentation: false      # TSO - Disable to prevent e1000e driver bugs
+  tx-generic-segmentation: false  # GSO - Disable to prevent adapter resets
+  rx-gro: false                   # GRO - Disable to prevent packet drops
+  rx-vlan-hw-parse: false         # VLAN RX - Disable to prevent drops with VLANs/bridges

--- a/talos/patches/intel-nuc-e1000e/kernel-params.yaml
+++ b/talos/patches/intel-nuc-e1000e/kernel-params.yaml
@@ -1,0 +1,29 @@
+---
+# Kernel parameters for Intel I219-V stability on Intel NUCs
+#
+# NOTE: This file is NOT CURRENTLY APPLIED due to systemd-boot/UKI limitations
+#
+# Talos 1.10+ uses systemd-boot with UKI (Unified Kernel Images) on UEFI systems.
+# With UKI, kernel arguments are embedded in the image and machine.install.extraKernelArgs
+# is ignored. Kernel params cannot be modified without upgrading the UKI itself.
+#
+# Reference: https://www.talos.dev/v1.11/talos-guides/install/bare-metal-platforms/bootloader/
+#
+# This file is preserved for documentation of the C-State issue, but ethernet-tuning.yaml
+# alone resolved packet drops without requiring kernel parameter changes.
+#
+# Original Problem: Intel e1000e driver can cause "Detected Hardware Unit Hang" errors
+# and complete system lockups when network adapter enters deep CPU power states.
+#
+# Intended Solution: Limit CPU C-State to prevent deep sleep states that cause e1000e hangs
+#
+# Trade-off: Slightly higher power consumption, but prevents network and system freezes
+#
+# References:
+# - https://askubuntu.com/questions/1376155/intel-i219-experiencing-huge-package-loss
+# - https://bbs.archlinux.org/viewtopic.php?id=255162
+# - Community reports of e1000e "hardware unit hang" errors
+machine:
+  install:
+    extraKernelArgs:
+      - intel_idle.max_cstate=1

--- a/talos/talconfig.yaml
+++ b/talos/talconfig.yaml
@@ -60,6 +60,8 @@ nodes:
         mtu: 1500
         vip:
           ip: "192.168.1.70"
+    extraManifests:
+      - '@./patches/intel-nuc-e1000e/ethernet-tuning.yaml'
   - hostname: "marin"
     ipAddress: "192.168.1.59"
     installDiskSelector:
@@ -80,6 +82,8 @@ nodes:
         mtu: 1500
         vip:
           ip: "192.168.1.70"
+    extraManifests:
+      - '@./patches/intel-nuc-e1000e/ethernet-tuning.yaml'
   - hostname: "sakura"
     ipAddress: "192.168.1.62"
     installDiskSelector:
@@ -99,6 +103,8 @@ nodes:
           - network: "0.0.0.0/0"
             gateway: "192.168.1.1"
         mtu: 1500
+    extraManifests:
+      - '@./patches/intel-nuc-e1000e/ethernet-tuning.yaml'
   - hostname: "hanekawa"
     ipAddress: "192.168.1.63"
     installDiskSelector:
@@ -118,6 +124,8 @@ nodes:
           - network: "0.0.0.0/0"
             gateway: "192.168.1.1"
         mtu: 1500
+    extraManifests:
+      - '@./patches/intel-nuc-e1000e/ethernet-tuning.yaml'
 
 # Global patches
 patches:


### PR DESCRIPTION
## Summary

Resolves `CephNodeNetworkPacketDrops` alert firing on node nami (192.168.1.50) by tuning the Intel I219-V (e1000e driver) ethernet adapter using Talos EthernetConfig.

## Problem Statement

The nami control plane node experienced persistent network packet drops under high Ceph storage traffic:
- **Current packet drops**: 3.2M receive drops on interface eno1
- **Alert threshold**: Drop rate >0.5% OR >10 packets/second
- **Network adapter**: Intel I219-V using e1000e driver
- **Current ring buffers**: RX/TX = 256 (default)
- **Current offloads**: TSO/GSO/GRO enabled

## Root Cause Analysis

Research identified two primary issues with Intel I219-V adapters:

1. **Insufficient ring buffers**: Default 256-entry buffers cannot handle burst traffic from Ceph storage operations
2. **Known e1000e driver bugs**: TSO/GSO/GRO hardware offload features cause packet drops and adapter resets under load

**References**:
- [Proxmox Forum: e1000e reset adapter unexpectedly](https://forum.proxmox.com/threads/e1000e-reset-adapter-unexpectedly.87769/)
- [Kernel Bugzilla: e1000e driver issues](https://bugzilla.kernel.org/show_bug.cgi?id=213377)
- [Talos Ethernet Configuration Guide](https://www.talos.dev/v1.11/talos-guides/network/ethernet-config/)

## Solution

Applied Talos-native EthernetConfig patch to nami node via talhelper:

1. **Increased ring buffers**: 256 → 4096 (16x larger, maximum supported)
2. **Disabled hardware offloads**: TSO, GSO, GRO (known to cause e1000e bugs)

This approach uses Talos' declarative machine configuration rather than runtime ethtool commands, ensuring settings persist across reboots and are managed via GitOps.

## Implementation Pattern

Following the pattern from [@buroa's k8s-gitops](https://github.com/buroa/k8s-gitops/blob/main/talos/talconfig.yaml):

```yaml
# talos/patches/nami/ethernet-tuning.yaml
apiVersion: v1alpha1
kind: EthernetConfig
name: eno1
rings:
  rx: 4096
  tx: 4096
features:
  tx-tcp-segmentation: false      # TSO
  tx-generic-segmentation: false  # GSO
  rx-gro: false                   # GRO
```

Referenced in talhelper config:
```yaml
# talos/talconfig.yaml
nodes:
  - hostname: "nami"
    patches:
      - '@./patches/nami/ethernet-tuning.yaml'
```

## Testing Plan

After applying this configuration (`task talos:generate-config && task talos:apply-config`):

1. **Verify settings applied**:
   ```bash
   talosctl -n 192.168.1.50 get ethernetstatus eno1 -o yaml
   ```
   Expected: `rx: 4096, tx: 4096`, TSO/GSO/GRO disabled

2. **Monitor packet drops**:
   ```bash
   kubectl exec -n rook-ceph deploy/rook-ceph-exporter -- cat /proc/net/dev | rg eno1
   ```
   Expected: Drop counter stops increasing

3. **Alert validation**: 
   Wait 15-30 minutes for `CephNodeNetworkPacketDrops` alert to clear

## Community Feedback Request

This solution was developed with guidance from the Home Operations community (special thanks to @onedr0p). Requesting review of:

- EthernetConfig implementation pattern
- Ring buffer sizing (4096 chosen as maximum supported)
- Hardware offload disablement approach
- Alternative solutions or considerations

## References

- Community discussion and guidance from onedr0p
- Implementation pattern: [@buroa/k8s-gitops](https://github.com/buroa/k8s-gitops)
- Talos documentation: [Ethernet Configuration](https://www.talos.dev/v1.11/talos-guides/network/ethernet-config/)